### PR TITLE
refactor: inline p-limit, drop dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "typecheck:ts7": "tsgo -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "p-limit": "7.3.0",
     "pdfjs-dist": "5.7.284"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@napi-rs/canvas':
         specifier: '>=0.1.100'
         version: 0.1.100
-      p-limit:
-        specifier: 7.3.0
-        version: 7.3.0
       pdfjs-dist:
         specifier: 5.7.284
         version: 5.7.284
@@ -1999,10 +1996,6 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-limit@7.3.0:
-    resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
-    engines: {node: '>=20'}
-
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
@@ -2577,10 +2570,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yocto-queue@1.2.2:
-    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
-    engines: {node: '>=12.20'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -4424,10 +4413,6 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@7.3.0:
-    dependencies:
-      yocto-queue: 1.2.2
-
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
@@ -4994,8 +4979,6 @@ snapshots:
       yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.2: {}
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,7 +5,6 @@ import {
   CanvasRenderingContext2D,
   createCanvas,
 } from '@napi-rs/canvas';
-import pLimit from 'p-limit';
 import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs';
 import type {
   PDFPageProxy,
@@ -13,6 +12,29 @@ import type {
 } from 'pdfjs-dist/types/src/display/api.js';
 
 import { resolveInput } from '#afpp/src/resolveInput';
+
+function pLimit(concurrency: number) {
+  const queue: Array<() => void> = [];
+  let active = 0;
+  const next = () => {
+    if (active < concurrency && queue.length > 0) {
+      active++;
+      queue.shift()!();
+    }
+  };
+  return <T>(fn: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      queue.push(() => {
+        fn()
+          .then(resolve, reject)
+          .finally(() => {
+            active--;
+            next();
+          });
+      });
+      next();
+    });
+}
 
 export enum PROCESSING_TYPE {
   IMAGE = 'IMAGE',


### PR DESCRIPTION
Replaces the p-limit package (and its yocto-queue transitive dep) with a
minimal 20-line concurrency limiter inlined in core.ts. Only the basic
limit(fn) call pattern is used — no activeCount, clearQueue, or
concurrency setter needed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
