### PR TITLE
feat!: add ESM support, drop CJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The project was created to address recurring problems encountered with existing 
 
 ## Key Features
 
-- No manual build step required — prebuilt native binaries are bundled automatically via `@napi-rs/canvas`
+- No manual build step required for text extraction; image rendering requires the optional peer dep `@napi-rs/canvas` (prebuilt native binaries, no compile step)
 - Fully asynchronous, non-blocking architecture
 - First-class TypeScript support
 - Supports local files, buffers, and remote URLs
@@ -89,12 +89,10 @@ console.log(pages); // ['Page 1 text', 'Page 2 text', ...]
 ```ts
 import { pdf2image } from 'afpp';
 
-(async () => {
-  const url = new URL('https://pdfobject.com/pdf/sample.pdf');
-  const images = await pdf2image(url);
+const url = new URL('https://pdfobject.com/pdf/sample.pdf');
+const images = await pdf2image(url);
 
-  console.log(images); // [Buffer, Buffer, ...]
-})();
+console.log(images); // [Buffer, Buffer, ...]
 ```
 
 ---
@@ -155,13 +153,11 @@ For advanced use cases, `parsePdf` exposes page-level control and transformation
 ```ts
 import { parsePdf } from 'afpp';
 
-(async () => {
-  const response = await fetch('https://pdfobject.com/pdf/sample.pdf');
-  const buffer = Buffer.from(await response.arrayBuffer());
+const response = await fetch('https://pdfobject.com/pdf/sample.pdf');
+const buffer = Buffer.from(await response.arrayBuffer());
 
-  const result = await parsePdf(buffer, {}, (pageContent) => pageContent);
-  console.log(result);
-})();
+const result = await parsePdf(buffer, {}, (pageContent) => pageContent);
+console.log(result);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The project was created to address recurring problems encountered with existing 
 
 - **Node.js** >= 22.14.0
 
+> **v3 breaking change:** `afpp` is now ESM-only. Replace any `require('afpp')` calls with `import ... from 'afpp'`.
+
 ---
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -28,8 +28,18 @@
     "README.md",
     "LICENSE"
   ],
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "imports": {
+    "#afpp/src/*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "format": "oxfmt .",

--- a/src/core.ts
+++ b/src/core.ts
@@ -11,7 +11,7 @@ import type {
   TextItem,
 } from 'pdfjs-dist/types/src/display/api.js';
 
-import { resolveInput } from '#afpp/src/resolveInput';
+import { resolveInput } from '#afpp/src/resolveInput.js';
 
 function pLimit(concurrency: number) {
   const queue: Array<() => void> = [];

--- a/src/getPdfMetadata.ts
+++ b/src/getPdfMetadata.ts
@@ -1,7 +1,7 @@
 import { getDocument, PDFDateString } from 'pdfjs-dist/legacy/build/pdf.mjs';
 
-import type { AfppParseOptions } from '#afpp/src/core';
-import { resolveInput } from '#afpp/src/resolveInput';
+import type { AfppParseOptions } from '#afpp/src/core.js';
+import { resolveInput } from '#afpp/src/resolveInput.js';
 
 export interface PdfMetadata {
   title?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,9 @@ export type {
   ImageEncoding,
   PageProcessor,
   StreamingResult,
-} from '#afpp/src/core';
-export { getPdfMetadata, type PdfMetadata } from '#afpp/src/getPdfMetadata';
-export { parsePdf } from '#afpp/src/parsePdf';
-export { pdf2image } from '#afpp/src/pdf2image';
-export { pdf2string } from '#afpp/src/pdf2string';
-export { streamPdf2image, streamPdf2string } from '#afpp/src/streamPdf';
+} from '#afpp/src/core.js';
+export { getPdfMetadata, type PdfMetadata } from '#afpp/src/getPdfMetadata.js';
+export { parsePdf } from '#afpp/src/parsePdf.js';
+export { pdf2image } from '#afpp/src/pdf2image.js';
+export { pdf2string } from '#afpp/src/pdf2string.js';
+export { streamPdf2image, streamPdf2string } from '#afpp/src/streamPdf.js';

--- a/src/parsePdf.ts
+++ b/src/parsePdf.ts
@@ -3,7 +3,7 @@ import {
   PageProcessor,
   parsePdfFile,
   PROCESSING_TYPE,
-} from '#afpp/src/core';
+} from '#afpp/src/core.js';
 
 /**
  * Converts a PDF file from various input formats (Buffer, Uint8Array, string path, or URL). Pages are returned in mixed array of strings (text content) and buffers (image content) via callback function.

--- a/src/pdf2image.ts
+++ b/src/pdf2image.ts
@@ -2,7 +2,7 @@ import {
   AfppParseOptions,
   parsePdfFile,
   PROCESSING_TYPE,
-} from '#afpp/src/core';
+} from '#afpp/src/core.js';
 
 /**
  * Converts a PDF file from various input formats (Buffer, Uint8Array, string path, or URL) to an array of image buffers.

--- a/src/pdf2string.ts
+++ b/src/pdf2string.ts
@@ -2,7 +2,7 @@ import {
   AfppParseOptions,
   parsePdfFile,
   PROCESSING_TYPE,
-} from '#afpp/src/core';
+} from '#afpp/src/core.js';
 
 /**
  * Converts a PDF file from various input formats (Buffer, Uint8Array, string path, or URL) to a string.

--- a/src/streamPdf.ts
+++ b/src/streamPdf.ts
@@ -3,7 +3,7 @@ import {
   PROCESSING_TYPE,
   StreamingResult,
   streamPdfFile,
-} from '#afpp/src/core';
+} from '#afpp/src/core.js';
 
 /**
  * Streams PDF pages as images, yielding each page as it's processed.

--- a/test/getPdfMetadata.test.ts
+++ b/test/getPdfMetadata.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { getPdfMetadata } from '#afpp/src/index';
+import { getPdfMetadata } from '#afpp/src/index.js';
 
 describe('getPdfMetadata', () => {
   describe('input != string, buffer, Uint8Array or URL', () => {

--- a/test/parsePdf.test.ts
+++ b/test/parsePdf.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { parsePdf } from '#afpp/src/index';
+import { parsePdf } from '#afpp/src/index.js';
 
 describe('parsePdf', () => {
   describe('input != string, buffer, Uint8Array or URL  ', () => {

--- a/test/pdf2image.test.ts
+++ b/test/pdf2image.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { pdf2image } from '#afpp/src/index';
+import { pdf2image } from '#afpp/src/index.js';
 
 describe('pdf2image', () => {
   describe('input != string, buffer, Uint8Array or URL  ', () => {

--- a/test/pdf2string.test.ts
+++ b/test/pdf2string.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { pdf2string } from '#afpp/src/index';
+import { pdf2string } from '#afpp/src/index.js';
 
 describe('pdf2string', () => {
   describe('input != string, buffer, Uint8Array or URL  ', () => {

--- a/test/resolveInput.test.ts
+++ b/test/resolveInput.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { resolveInput } from '#afpp/src/resolveInput';
+import { resolveInput } from '#afpp/src/resolveInput.js';
 
 describe('resolveInput', () => {
   describe('invalid input', () => {

--- a/test/streamPdf.test.ts
+++ b/test/streamPdf.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { streamPdf2image, streamPdf2string } from '#afpp/src/index';
+import { streamPdf2image, streamPdf2string } from '#afpp/src/index.js';
 
 describe('streamPdf2image', () => {
   describe('input != string, buffer, Uint8Array or URL', () => {


### PR DESCRIPTION
BREAKING CHANGE: package now ships ESM only. CJS consumers
(require('afpp')) must migrate to import.

- Add "type": "module" and "exports" to package.json
- Add "imports" for NodeNext subpath resolution
- Add .js extension to all internal #afpp/src/* specifiers
  (required by NodeNext ESM module resolution)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
