### PR TITLE
ci: auto-merge patch/minor Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a workflow that auto-merges Dependabot PRs (squash) once CI passes, for patch/minor version bumps only — major bumps stay manual.
- Relies on branch protection on `main` requiring the `Test` check, added separately, so a broken bump (e.g. #244) can't auto-merge.

## Test plan
- [ ] Confirm this PR's own `Test` check passes and it merges cleanly (manually, since it's not a Dependabot PR).
- [ ] Watch the next Dependabot PR to confirm auto-merge triggers correctly for a patch/minor bump.