### PR TITLE
chore(lint): vendor anti-slop oxlint plugin

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,14 +7,33 @@
     "typescript/require-await": "error",
     "typescript/no-unsafe-assignment": "warn",
     "typescript/no-unsafe-call": "warn",
-    "typescript/no-unsafe-return": "warn"
+    "typescript/no-unsafe-return": "warn",
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-conditional-empty-object-spread": "error",
+    "anti-slop/no-known-value-widening": "error",
+    "anti-slop/no-module-mocking": "error",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+    "anti-slop/no-runtime-typeof": "error",
+    "anti-slop/no-shape-in-symbol-names": "error",
+    "anti-slop/no-unknown-parameters": "error",
+    "anti-slop/no-unknown-returns": "error",
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-unsafe-dictionary-type": "error",
+    "anti-slop/no-widen-then-assert": "error",
+    "anti-slop/require-safety-comment-for-type-assertion": "error"
   },
   "ignorePatterns": [
     "dist",
     "node_modules",
     "coverage",
     "examples",
-    "benchmark"
+    "benchmark",
+    ".agent/**",
+    ".agents/**",
+    ".claude/**",
+    "tools/oxlint/anti-slop/**"
   ],
   "overrides": [
     {
@@ -22,6 +41,12 @@
       "rules": {
         "typescript/no-floating-promises": "off"
       }
+    }
+  ],
+  "jsPlugins": [
+    {
+      "name": "anti-slop",
+      "specifier": "./tools/oxlint/anti-slop/index.ts"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.1.0",
     "@commitlint/config-conventional": "21.1.0",
+    "@oxlint/plugins": "1.79.0",
     "@types/node": "25.9.3",
     "@typescript/native-preview": "7.0.0-dev.20260612.1",
     "@voxpelli/node-test-pretty-reporter": "1.1.2",
@@ -71,7 +72,7 @@
     "husky": "9.1.7",
     "lint-staged": "17.0.8",
     "oxfmt": "0.56.0",
-    "oxlint": "1.71.0",
+    "oxlint": "1.79.0",
     "oxlint-tsgolint": "0.23.0",
     "semantic-release": "25.0.5",
     "tsc-alias": "1.8.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: 21.1.0
         version: 21.1.0
+      '@oxlint/plugins':
+        specifier: 1.79.0
+        version: 1.79.0
       '@types/node':
         specifier: 25.9.3
         version: 25.9.3
@@ -43,8 +46,8 @@ importers:
         specifier: 0.56.0
         version: 0.56.0
       oxlint:
-        specifier: 1.71.0
-        version: 1.71.0(oxlint-tsgolint@0.23.0)
+        specifier: 1.79.0
+        version: 1.79.0(oxlint-tsgolint@0.23.0)
       oxlint-tsgolint:
         specifier: 0.23.0
         version: 0.23.0
@@ -637,127 +640,131 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.71.0':
-    resolution: {integrity: sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g==}
+  '@oxlint/binding-android-arm-eabi@1.79.0':
+    resolution: {integrity: sha512-TebFaaMklO/RXzTv7PucaCq9l3X6D1gA+C8H6K4njtjFOV+zWE9MKLpulcJZN9bzytbUbQIY0mZuz12nQ5Kv4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.71.0':
-    resolution: {integrity: sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw==}
+  '@oxlint/binding-android-arm64@1.79.0':
+    resolution: {integrity: sha512-KqqnOtAVgNsPPF0YSodkFZA1O80jcKoCZCTu3bgsszxA+MrMP9TLzfXitKjEj1FmrPprKDMdRDMmY3weESO9sg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.71.0':
-    resolution: {integrity: sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ==}
+  '@oxlint/binding-darwin-arm64@1.79.0':
+    resolution: {integrity: sha512-BVC2nsMzqQzRDPc5RhixkZ+m1p7iH4bxRRvqkbwDXX0PlQKm1BPy8J8cRjnAFafOq2QzI+BfO3vE8w2GZ3CBag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.71.0':
-    resolution: {integrity: sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg==}
+  '@oxlint/binding-darwin-x64@1.79.0':
+    resolution: {integrity: sha512-p6Lm+snmhGuLKL1+CpCV8L6ijkE/qJzK2H2jG9+eKJT0n31RbY4FLsdhexekgP3bLpw4Kgde+9DZuDZQ4yIInA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.71.0':
-    resolution: {integrity: sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ==}
+  '@oxlint/binding-freebsd-x64@1.79.0':
+    resolution: {integrity: sha512-qDMm0dXZnoHyRqSL4N4xUq82T4sqK5cbKSjvd/dF/YbMUXc2R1wEPf+vmA5S0qUmi0nwXfNbjXBtZaIqzQLIMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.71.0':
-    resolution: {integrity: sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.79.0':
+    resolution: {integrity: sha512-2od7s0nuKPzqyUZAWk9KkCyGg7eI9dwFPZg+20lB15fKFkVZ0c9ZFxqPfiBAyDTlTkh9stPI0t+JlPCqMbItVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.71.0':
-    resolution: {integrity: sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw==}
+  '@oxlint/binding-linux-arm-musleabihf@1.79.0':
+    resolution: {integrity: sha512-ZOQUjkzDnvlhSE3+tWC3YXx94MMl+sYMlwH+u1+YGApGHOJP/YAc8ZBRFOXZ6eOBmxtXAWuS/fBcdZr8qqNO1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.71.0':
-    resolution: {integrity: sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w==}
+  '@oxlint/binding-linux-arm64-gnu@1.79.0':
+    resolution: {integrity: sha512-lu158FR4nGqGeRS3BQvtG85wRgU/Fy4MD5Cxp1hzJXizGiLo6u2742wJSCDKh8cFcZntvX7fcxlq4mMmfryH1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.71.0':
-    resolution: {integrity: sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==}
+  '@oxlint/binding-linux-arm64-musl@1.79.0':
+    resolution: {integrity: sha512-mbpKQeE2aflTjddaHK7MP8KP/OFbUM++lt5M635ENM8IyIdK0jm2t9pb+2v9mVVIvhF6TqA4l7F79Pll1mi+uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.71.0':
-    resolution: {integrity: sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==}
+  '@oxlint/binding-linux-ppc64-gnu@1.79.0':
+    resolution: {integrity: sha512-WpGNua7gaxaHnpSDeog2ji8IDHn/QLPl9LPzwkR/FvVv58vT5BcXjRXnU+wbu3N75cpeha8CdC7ho/U2OIsB4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.71.0':
-    resolution: {integrity: sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==}
+  '@oxlint/binding-linux-riscv64-gnu@1.79.0':
+    resolution: {integrity: sha512-tK1E93A5LVzISg4ngpKJnfTs7EqtIUceGI7MQ4GyDjJiLi8wPCkEyKlj2xkyKWZ1yzkDJyLHTBJ5/iFWRdnJvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.71.0':
-    resolution: {integrity: sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==}
+  '@oxlint/binding-linux-riscv64-musl@1.79.0':
+    resolution: {integrity: sha512-qhQvUIrngXivA2A9pQ+xPCychztn/5qUv7yS3gDwXv3w7Rag+eTeeXWmRyx+t7XsW5x6LuY/8AsTq36UgFIblg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.71.0':
-    resolution: {integrity: sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==}
+  '@oxlint/binding-linux-s390x-gnu@1.79.0':
+    resolution: {integrity: sha512-sv6AaVgU/eE6u+6WFiQVDcPPwTxP6IJMSB9k701W2r/r6Tx465e8vPvVyRxquNH4Vy6KwRNu90mVbxXJN8+5gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.71.0':
-    resolution: {integrity: sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==}
+  '@oxlint/binding-linux-x64-gnu@1.79.0':
+    resolution: {integrity: sha512-iFZL02deziHslb3jEX9KdqlAkYoo4fGyotchKDzdfK1f5mxlIBeiQeHhvK3iFpuEJSB4ma/qeFn9oxPiwnhUPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.71.0':
-    resolution: {integrity: sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==}
+  '@oxlint/binding-linux-x64-musl@1.79.0':
+    resolution: {integrity: sha512-3DtZR2raqObnh7wXZoFYFd0Fw7skBvcb3f7A+/lkEiDuh8hrE6vv9b/62Qxao1a9/OeHLw/FcXlXzgsW9wTRFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.71.0':
-    resolution: {integrity: sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==}
+  '@oxlint/binding-openharmony-arm64@1.79.0':
+    resolution: {integrity: sha512-Oatt4GuA1WJkqzk2ozx4HrWROOi7opV3AKDw/U8qDIqeTqzsjn5K2x3REJMNjU3/KU/Bkq96Zi3CknaiDTaC/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.71.0':
-    resolution: {integrity: sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA==}
+  '@oxlint/binding-win32-arm64-msvc@1.79.0':
+    resolution: {integrity: sha512-NAgZr9Qp8nIA9rpo0JEvwiabTF/2UVqBNnupBG9X4kxXcQoScJUTi+qHhvabb9s/thgj5wQ4XcIaJvb+ZMgoKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.71.0':
-    resolution: {integrity: sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw==}
+  '@oxlint/binding-win32-ia32-msvc@1.79.0':
+    resolution: {integrity: sha512-+KyXjIvcpaXmWW/j9NNY5yWjrIVxaX18VyIheQy3jwc2GSYgpCr7MGI/HxIGQ/shAL5IWEKbhsqoMpAO5Stiog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.71.0':
-    resolution: {integrity: sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ==}
+  '@oxlint/binding-win32-x64-msvc@1.79.0':
+    resolution: {integrity: sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxlint/plugins@1.79.0':
+    resolution: {integrity: sha512-S0uyoxakDINJ4DPgqxGlEEvrdSMeQb7Z2lKVjxoY2gwsbZbfg2Xr8Klfeo5ZeraHmmdBCELFUHkSe6KEmBpMvg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1917,12 +1924,12 @@ packages:
     resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
     hasBin: true
 
-  oxlint@1.71.0:
-    resolution: {integrity: sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw==}
+  oxlint@1.79.0:
+    resolution: {integrity: sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.22.1'
+      oxlint-tsgolint: '>=7.0.2001'
       vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
@@ -2964,62 +2971,64 @@ snapshots:
   '@oxlint-tsgolint/win32-x64@0.23.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.71.0':
+  '@oxlint/binding-android-arm-eabi@1.79.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.71.0':
+  '@oxlint/binding-android-arm64@1.79.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.71.0':
+  '@oxlint/binding-darwin-arm64@1.79.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.71.0':
+  '@oxlint/binding-darwin-x64@1.79.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.71.0':
+  '@oxlint/binding-freebsd-x64@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.71.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.71.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.71.0':
+  '@oxlint/binding-linux-arm64-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.71.0':
+  '@oxlint/binding-linux-arm64-musl@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.71.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.71.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.71.0':
+  '@oxlint/binding-linux-riscv64-musl@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.71.0':
+  '@oxlint/binding-linux-s390x-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.71.0':
+  '@oxlint/binding-linux-x64-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.71.0':
+  '@oxlint/binding-linux-x64-musl@1.79.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.71.0':
+  '@oxlint/binding-openharmony-arm64@1.79.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.71.0':
+  '@oxlint/binding-win32-arm64-msvc@1.79.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.71.0':
+  '@oxlint/binding-win32-ia32-msvc@1.79.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.71.0':
+  '@oxlint/binding-win32-x64-msvc@1.79.0':
     optional: true
+
+  '@oxlint/plugins@1.79.0': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -4260,27 +4269,27 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.71.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.79.0(oxlint-tsgolint@0.23.0):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.71.0
-      '@oxlint/binding-android-arm64': 1.71.0
-      '@oxlint/binding-darwin-arm64': 1.71.0
-      '@oxlint/binding-darwin-x64': 1.71.0
-      '@oxlint/binding-freebsd-x64': 1.71.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.71.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.71.0
-      '@oxlint/binding-linux-arm64-gnu': 1.71.0
-      '@oxlint/binding-linux-arm64-musl': 1.71.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.71.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.71.0
-      '@oxlint/binding-linux-riscv64-musl': 1.71.0
-      '@oxlint/binding-linux-s390x-gnu': 1.71.0
-      '@oxlint/binding-linux-x64-gnu': 1.71.0
-      '@oxlint/binding-linux-x64-musl': 1.71.0
-      '@oxlint/binding-openharmony-arm64': 1.71.0
-      '@oxlint/binding-win32-arm64-msvc': 1.71.0
-      '@oxlint/binding-win32-ia32-msvc': 1.71.0
-      '@oxlint/binding-win32-x64-msvc': 1.71.0
+      '@oxlint/binding-android-arm-eabi': 1.79.0
+      '@oxlint/binding-android-arm64': 1.79.0
+      '@oxlint/binding-darwin-arm64': 1.79.0
+      '@oxlint/binding-darwin-x64': 1.79.0
+      '@oxlint/binding-freebsd-x64': 1.79.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.79.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.79.0
+      '@oxlint/binding-linux-arm64-gnu': 1.79.0
+      '@oxlint/binding-linux-arm64-musl': 1.79.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.79.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.79.0
+      '@oxlint/binding-linux-riscv64-musl': 1.79.0
+      '@oxlint/binding-linux-s390x-gnu': 1.79.0
+      '@oxlint/binding-linux-x64-gnu': 1.79.0
+      '@oxlint/binding-linux-x64-musl': 1.79.0
+      '@oxlint/binding-openharmony-arm64': 1.79.0
+      '@oxlint/binding-win32-arm64-msvc': 1.79.0
+      '@oxlint/binding-win32-ia32-msvc': 1.79.0
+      '@oxlint/binding-win32-x64-msvc': 1.79.0
       oxlint-tsgolint: 0.23.0
 
   p-each-series@3.0.0: {}

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,42 @@
+import { eslintCompatPlugin } from '@oxlint/plugins';
+
+import { noChainedTypeAssertionsRule } from './rules/no-chained-type-assertions.ts';
+import { noConditionalEmptyObjectSpreadRule } from './rules/no-conditional-empty-object-spread.ts';
+import { noKnownValueWideningRule } from './rules/no-known-value-widening.ts';
+import { noModuleMockingRule } from './rules/no-module-mocking.ts';
+import { noObjectParametersRule } from './rules/no-object-parameters.ts';
+import { noReflectApplyRule } from './rules/no-reflect-apply.ts';
+import { noReflectGetRule } from './rules/no-reflect-get.ts';
+import { noRuntimeTypeofRule } from './rules/no-runtime-typeof.ts';
+import { noForbiddenTermInSymbolNamesRule } from './rules/no-shape-in-symbol-names.ts';
+import { noUnknownParametersRule } from './rules/no-unknown-parameters.ts';
+import { noUnknownReturnsRule } from './rules/no-unknown-returns.ts';
+import { noUnknownTypeAliasesRule } from './rules/no-unknown-type-aliases.ts';
+import { noUnsafeDictionaryTypeRule } from './rules/no-unsafe-dictionary-type.ts';
+import { noWidenThenAssertRule } from './rules/no-widen-then-assert.ts';
+import { requireSafetyCommentForTypeAssertionRule } from './rules/require-safety-comment-for-type-assertion.ts';
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = eslintCompatPlugin({
+  meta: { name: 'anti-slop' },
+  rules: {
+    'no-chained-type-assertions': noChainedTypeAssertionsRule,
+    'no-conditional-empty-object-spread': noConditionalEmptyObjectSpreadRule,
+    'no-known-value-widening': noKnownValueWideningRule,
+    'no-module-mocking': noModuleMockingRule,
+    'no-object-parameters': noObjectParametersRule,
+    'no-reflect-apply': noReflectApplyRule,
+    'no-reflect-get': noReflectGetRule,
+    'no-runtime-typeof': noRuntimeTypeofRule,
+    'no-unsafe-dictionary-type': noUnsafeDictionaryTypeRule,
+    'no-shape-in-symbol-names': noForbiddenTermInSymbolNamesRule,
+    'no-unknown-parameters': noUnknownParametersRule,
+    'no-unknown-returns': noUnknownReturnsRule,
+    'no-unknown-type-aliases': noUnknownTypeAliasesRule,
+    'no-widen-then-assert': noWidenThenAssertRule,
+    'require-safety-comment-for-type-assertion':
+      requireSafetyCommentForTypeAssertionRule,
+  },
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,88 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(
+  node: ESTree.Node,
+): node is TypeAssertionExpression {
+  return node.type === 'TSAsExpression' || node.type === 'TSTypeAssertion';
+}
+
+function unwrapParenthesizedExpression(
+  expression: ESTree.Expression,
+): ESTree.Expression {
+  let current = expression;
+  while (current.type === 'ParenthesizedExpression') {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === 'TSTypeReference' &&
+    typeAnnotation.typeName.type === 'Identifier' &&
+    typeAnnotation.typeName.name === 'const'
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (
+    parent.type === 'ParenthesizedExpression' &&
+    parent.expression === current
+  ) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.',
+    },
+    messages: {
+      chained:
+        'This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.',
+    },
+  },
+  createOnce(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (
+        !isOutermostAssertionInChain(node) ||
+        !isForbiddenAssertionChain(node)
+      )
+        return;
+      context.report({ node, messageId: 'chained' });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,49 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === 'ParenthesizedExpression') {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === 'ObjectExpression' && node.properties.length === 0;
+}
+
+function isConditionalEmptyObjectSpread(node: ESTree.Expression): boolean {
+  const conditional = unwrapParentheses(node);
+  return (
+    conditional.type === 'ConditionalExpression' &&
+    (isEmptyObjectExpression(conditional.consequent) ||
+      isEmptyObjectExpression(conditional.alternate))
+  );
+}
+
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow object spreads that conditionally spread an empty object to omit fields.',
+    },
+    messages: {
+      avoid:
+        'This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.',
+    },
+  },
+  createOnce(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== 'ObjectExpression') return;
+
+        if (isConditionalEmptyObjectSpread(node.argument)) {
+          context.report({ node, messageId: 'avoid' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,272 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree, Scope, SourceCode, Variable } from '@oxlint/plugins';
+
+import {
+  classifyWideningTarget,
+  createTypeEnvironment,
+  isKnownEvidenceExpression,
+  type TypeEnvironment,
+  type WideningTarget,
+} from '../shared/dictionary-types.ts';
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (
+    current.type === 'ParenthesizedExpression' ||
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSSatisfiesExpression' ||
+    current.type === 'TSTypeAssertion' ||
+    current.type === 'TSNonNullExpression'
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function variableDeclarator(
+  variable: Variable,
+): ESTree.VariableDeclarator | null {
+  if (variable.defs.length !== 1) return null;
+  const [definition] = variable.defs;
+  return definition?.type === 'Variable' &&
+    definition.node.type === 'VariableDeclarator'
+    ? definition.node
+    : null;
+}
+
+function isStableConstVariable(
+  variable: Variable,
+  declarator: ESTree.VariableDeclarator,
+): boolean {
+  return (
+    declarator.parent.type === 'VariableDeclaration' &&
+    declarator.parent.kind === 'const' &&
+    variable.references.every(
+      (reference) => reference.init || !reference.isWrite(),
+    )
+  );
+}
+
+function hasKnownEvidence(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+  visitedVariables = new Set<Variable>(),
+): boolean {
+  if (isKnownEvidenceExpression(expression)) return true;
+  const unwrapped = unwrapExpression(expression);
+  if (unwrapped.type !== 'Identifier') return false;
+  const variable = resolveVariable(sourceCode, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return false;
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.init === null ||
+    !isStableConstVariable(variable, declarator)
+  ) {
+    return false;
+  }
+  visitedVariables.add(variable);
+  return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function annotationTarget(
+  annotation: ESTree.TSTypeAnnotation | null | undefined,
+  environment: TypeEnvironment,
+): WideningTarget | null {
+  return annotation === null || annotation === undefined
+    ? null
+    : classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (
+      current.type === 'ArrowFunctionExpression' ||
+      current.type === 'FunctionDeclaration' ||
+      current.type === 'FunctionExpression'
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function sourceKeyName(
+  sourceCode: SourceCode,
+  key: ESTree.PropertyKey,
+): string {
+  if (key.type === 'Identifier' || key.type === 'PrivateIdentifier')
+    return key.name;
+  if (key.type === 'Literal') return String(key.value);
+  return sourceCode.getText(key);
+}
+
+function functionName(
+  sourceCode: SourceCode,
+  owner: FunctionExpression | null,
+): string {
+  if (owner === null) return 'anonymous function';
+  if (owner.id !== null) return owner.id.name;
+  const parent = owner.parent;
+  if (parent.type === 'VariableDeclarator' && parent.id.type === 'Identifier')
+    return parent.id.name;
+  if (parent.type === 'MethodDefinition')
+    return sourceKeyName(sourceCode, parent.key);
+  return 'anonymous function';
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+  const unwrapped = unwrapExpression(expression);
+  return (
+    unwrapped.type === 'ObjectExpression' && unwrapped.properties.length === 0
+  );
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+  return (
+    destination.kind === 'open dictionary' ||
+    destination.kind === 'generic container'
+  );
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+  return (
+    node.parent?.type === 'TSAsExpression' ||
+    node.parent?.type === 'TSTypeAssertion'
+  );
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.',
+    },
+    messages: {
+      widening:
+        'The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.',
+    },
+  },
+  createOnce(context) {
+    let environment: TypeEnvironment | null = null;
+
+    const reportFlow = (
+      expression: ESTree.Expression,
+      destination: WideningTarget | null,
+      subject: string,
+    ) => {
+      if (destination === null) return;
+      if (
+        isDictionaryAccumulatorTarget(destination) &&
+        isEmptyObjectExpression(expression)
+      ) {
+        return;
+      }
+      if (!hasKnownEvidence(context.sourceCode, expression)) return;
+      context.report({
+        node: expression,
+        messageId: 'widening',
+        data: { subject, target: destination.kind },
+      });
+    };
+
+    const targetFromAnnotation = (
+      annotation: ESTree.TSTypeAnnotation | null | undefined,
+    ) =>
+      environment === null ? null : annotationTarget(annotation, environment);
+
+    return {
+      Program(node) {
+        environment = createTypeEnvironment(node);
+      },
+      VariableDeclarator(node) {
+        if (node.init === null || node.id.type !== 'Identifier') return;
+        reportFlow(
+          node.init,
+          targetFromAnnotation(node.id.typeAnnotation),
+          `binding \`${node.id.name}\``,
+        );
+      },
+      PropertyDefinition(node) {
+        if (node.value === null) return;
+        reportFlow(
+          node.value,
+          targetFromAnnotation(node.typeAnnotation),
+          `property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+        );
+      },
+      AccessorProperty(node) {
+        if (node.value === null) return;
+        reportFlow(
+          node.value,
+          targetFromAnnotation(node.typeAnnotation),
+          `property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+        );
+      },
+      AssignmentExpression(node) {
+        if (node.operator !== '=' || node.left.type !== 'Identifier') return;
+        const variable = resolveVariable(context.sourceCode, node.left);
+        if (variable === null) return;
+        const declarator = variableDeclarator(variable);
+        if (declarator === null || declarator.id.type !== 'Identifier') return;
+        reportFlow(
+          node.right,
+          targetFromAnnotation(declarator.id.typeAnnotation),
+          `binding \`${declarator.id.name}\``,
+        );
+      },
+      ReturnStatement(node) {
+        if (node.argument === null) return;
+        const owner = enclosingFunction(node);
+        reportFlow(
+          node.argument,
+          targetFromAnnotation(owner?.returnType),
+          `return value of \`${functionName(context.sourceCode, owner)}\``,
+        );
+      },
+      ArrowFunctionExpression(node) {
+        if (node.body.type === 'BlockStatement') return;
+        reportFlow(
+          node.body,
+          targetFromAnnotation(node.returnType),
+          `return value of \`${functionName(context.sourceCode, node)}\``,
+        );
+      },
+      TSAsExpression(node) {
+        if (environment === null || hasParentAssertion(node)) return;
+        reportFlow(
+          node.expression,
+          classifyWideningTarget(node.typeAnnotation, environment),
+          'assertion',
+        );
+      },
+      TSTypeAssertion(node) {
+        if (environment === null || hasParentAssertion(node)) return;
+        reportFlow(
+          node.expression,
+          classifyWideningTarget(node.typeAnnotation, environment),
+          'assertion',
+        );
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,110 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree, Scope, SourceCode, Variable } from '@oxlint/plugins';
+
+const moduleMockMethods = new Set(['doMock', 'mock', 'unstable_mockModule']);
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== 'ImportSpecifier') return null;
+  return node.imported.type === 'Identifier'
+    ? node.imported.name
+    : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== 'Identifier') return false;
+  if (
+    (expression.name === 'vi' || expression.name === 'jest') &&
+    sourceCode.isGlobalReference(expression)
+  ) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === 'vi' || expression.name === 'jest';
+  }
+  return variable.defs.some((definition) => {
+    if (
+      definition.type !== 'ImportBinding' ||
+      definition.parent?.type !== 'ImportDeclaration'
+    ) {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (
+      (source === 'vitest' && name === 'vi') ||
+      (source === '@jest/globals' && name === 'jest')
+    );
+  });
+}
+
+function moduleMockCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+): boolean {
+  if (
+    !('property' in callee) ||
+    !('object' in callee) ||
+    !('computed' in callee)
+  )
+    return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === 'Literal' &&
+      (property.value === 'doMock' ||
+        property.value === 'mock' ||
+        property.value === 'unstable_mockModule')
+      ? property.value
+      : null
+    : property.type === 'Identifier'
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.',
+    },
+    messages: {
+      moduleMock:
+        'Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.',
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Super' ||
+          node.callee.type === 'V8IntrinsicExpression'
+        )
+          return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: 'moduleMock' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,131 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree, SourceCode } from '@oxlint/plugins';
+
+import { lexicalTypeParameterNames } from '../shared/lexical-type-parameters.ts';
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(
+  parameter: Parameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === 'TSParameterProperty') {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === 'RestElement') {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === 'AssignmentPattern') {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceCode: SourceCode): string {
+  return parameter.type === 'Identifier'
+    ? parameter.name
+    : sourceCode.getText(parameter).replace(/\s*:\s*object\s*$/u, '');
+}
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.',
+    },
+    messages: {
+      objectParameter:
+        'Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.',
+    },
+  },
+  createOnce(context) {
+    const aliases = new Map<string, ESTree.TSType>();
+
+    const resolvesToObject = (
+      type: ESTree.TSType,
+      shadowedAliases: ReadonlySet<string>,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === 'TSObjectKeyword') return true;
+      if (type.type === 'TSParenthesizedType')
+        return resolvesToObject(type.typeAnnotation, shadowedAliases, visited);
+      if (type.type === 'TSUnionType') {
+        return type.types.some((member) =>
+          resolvesToObject(member, shadowedAliases, visited),
+        );
+      }
+      if (
+        type.type !== 'TSTypeReference' ||
+        type.typeName.type !== 'Identifier' ||
+        (type.typeArguments !== null &&
+          type.typeArguments !== undefined &&
+          type.typeArguments.params.length > 0) ||
+        visited.has(type.typeName.name) ||
+        shadowedAliases.has(type.typeName.name)
+      ) {
+        return false;
+      }
+      const alias = aliases.get(type.typeName.name);
+      if (alias === undefined) return false;
+      const nextVisited = new Set(visited);
+      nextVisited.add(type.typeName.name);
+      return resolvesToObject(alias, shadowedAliases, nextVisited);
+    };
+
+    const checkParameters = (node: ParameterOwner) => {
+      const shadowedAliases = lexicalTypeParameterNames(
+        node,
+        context.sourceCode.visitorKeys,
+      );
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!resolvesToObject(annotation.typeAnnotation, shadowedAliases))
+          continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: 'objectParameter',
+          data: { parameter: parameterName(parameter, context.sourceCode) },
+        });
+      }
+    };
+
+    return {
+      Program(node) {
+        aliases.clear();
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === 'ExportNamedDeclaration'
+              ? statement.declaration
+              : statement;
+          if (
+            declaration?.type === 'TSTypeAliasDeclaration' &&
+            (declaration.typeParameters === null ||
+              declaration.typeParameters === undefined)
+          ) {
+            aliases.set(declaration.id.name, declaration.typeAnnotation);
+          }
+        }
+      },
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,34 @@
+import { defineRule } from '@oxlint/plugins';
+
+import { isGlobalReflectMethodCall } from '../shared/reflect-method.ts';
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.',
+    },
+    messages: {
+      reflectApply:
+        'Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.',
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Super' ||
+          node.callee.type === 'V8IntrinsicExpression'
+        )
+          return;
+        if (
+          isGlobalReflectMethodCall(context.sourceCode, node.callee, 'apply')
+        ) {
+          context.report({ node, messageId: 'reflectApply' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,32 @@
+import { defineRule } from '@oxlint/plugins';
+
+import { isGlobalReflectMethodCall } from '../shared/reflect-method.ts';
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.',
+    },
+    messages: {
+      reflectGet:
+        'Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.',
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Super' ||
+          node.callee.type === 'V8IntrinsicExpression'
+        )
+          return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, 'get')) {
+          context.report({ node, messageId: 'reflectGet' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,66 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+type RuntimeFunction = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function isRuntimeFunction(node: ESTree.Node): node is RuntimeFunction {
+  return (
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression'
+  );
+}
+
+function isInsideTypeGuard(node: ESTree.Node): boolean {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (isRuntimeFunction(current)) {
+      return current.returnType?.typeAnnotation.type === 'TSTypePredicate';
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.',
+    },
+    messages: {
+      runtimeTypeof:
+        'A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowInTypeGuards: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{ allowInTypeGuards: false }],
+  },
+  createOnce(context) {
+    return {
+      UnaryExpression(node) {
+        const option = context.options?.[0];
+        const allowInTypeGuards =
+          typeof option === 'object' &&
+          option !== null &&
+          !Array.isArray(option) &&
+          option.allowInTypeGuards === true;
+        if (
+          node.operator === 'typeof' &&
+          (!allowInTypeGuards || !isInsideTypeGuard(node))
+        ) {
+          context.report({ node, messageId: 'runtimeTypeof' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,41 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+const FORBIDDEN_SYMBOL_NAME = 'shape';
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+    },
+  },
+  createOnce(context) {
+    const reportForbiddenSymbolName = (
+      node: ESTree.Node & { name: string },
+    ) => {
+      if (!containsForbiddenSymbolName(node.name)) return;
+      context.report({
+        node,
+        messageId: 'forbiddenSymbolName',
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,88 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(
+  parameter: Parameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === 'TSParameterProperty') {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === 'RestElement') {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === 'AssignmentPattern') {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceText: string): string {
+  if (parameter.type === 'TSParameterProperty') {
+    return parameterName(parameter.parameter, sourceText);
+  }
+  if (parameter.type === 'AssignmentPattern') {
+    return parameterName(parameter.left, sourceText);
+  }
+  if (parameter.type === 'RestElement') {
+    return parameterName(parameter.argument, sourceText);
+  }
+  return parameter.type === 'Identifier'
+    ? parameter.name
+    : sourceText.replace(/\s*:\s*unknown\s*$/u, '');
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow explicitly unknown function parameters except `cause`; decode unknown input at its I/O boundary instead.',
+    },
+    messages: {
+      unknownParameter:
+        'Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.',
+    },
+  },
+  createOnce(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation?.typeAnnotation.type !== 'TSUnknownKeyword') continue;
+        const name = parameterName(
+          parameter,
+          context.sourceCode.getText(parameter),
+        );
+        if (name === 'cause') continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: 'unknownParameter',
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
@@ -1,0 +1,130 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+import { lexicalTypeParameterNames } from '../shared/lexical-type-parameters.ts';
+
+type FunctionWithReturnType =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+  if (type.type === 'TSParenthesizedType')
+    return referencedAliasName(type.typeAnnotation);
+  if (type.type !== 'TSTypeReference' || type.typeName.type !== 'Identifier')
+    return null;
+  return type.typeArguments === null ||
+    type.typeArguments === undefined ||
+    type.typeArguments.params.length === 0
+    ? type.typeName.name
+    : null;
+}
+
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow functions whose explicit return contract is unknown or Promise<unknown>.',
+    },
+    messages: {
+      unknownReturn:
+        'This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.',
+    },
+  },
+  createOnce(context) {
+    const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+    const resolvesToUnknown = (
+      type: ESTree.TSType,
+      shadowedAliases: ReadonlySet<string>,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === 'TSUnknownKeyword') return true;
+      if (type.type === 'TSParenthesizedType') {
+        return resolvesToUnknown(type.typeAnnotation, shadowedAliases, visited);
+      }
+      if (type.type === 'TSUnionType') {
+        return type.types.some((member) =>
+          resolvesToUnknown(member, shadowedAliases, visited),
+        );
+      }
+      if (
+        type.type === 'TSTypeReference' &&
+        type.typeName.type === 'Identifier' &&
+        (type.typeName.name === 'Promise' ||
+          type.typeName.name === 'PromiseLike')
+      ) {
+        const value = type.typeArguments?.params[0];
+        return (
+          value !== undefined &&
+          resolvesToUnknown(value, shadowedAliases, visited)
+        );
+      }
+      const name = referencedAliasName(type);
+      if (name === null || visited.has(name) || shadowedAliases.has(name))
+        return false;
+      const alias = aliases.get(name);
+      if (
+        alias === undefined ||
+        (alias.typeParameters !== null && alias.typeParameters !== undefined)
+      ) {
+        return false;
+      }
+      const nextVisited = new Set(visited);
+      nextVisited.add(name);
+      return resolvesToUnknown(
+        alias.typeAnnotation,
+        shadowedAliases,
+        nextVisited,
+      );
+    };
+
+    const checkReturnType = (node: FunctionWithReturnType) => {
+      const annotation = node.returnType;
+      if (annotation === null || annotation === undefined) return;
+      if (
+        !resolvesToUnknown(
+          annotation.typeAnnotation,
+          lexicalTypeParameterNames(node, context.sourceCode.visitorKeys),
+        )
+      ) {
+        return;
+      }
+      context.report({
+        node: annotation.typeAnnotation,
+        messageId: 'unknownReturn',
+      });
+    };
+
+    return {
+      Program(node) {
+        aliases.clear();
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === 'ExportNamedDeclaration'
+              ? statement.declaration
+              : statement;
+          if (declaration?.type === 'TSTypeAliasDeclaration') {
+            aliases.set(declaration.id.name, declaration);
+          }
+        }
+      },
+      ArrowFunctionExpression: checkReturnType,
+      FunctionDeclaration: checkReturnType,
+      FunctionExpression: checkReturnType,
+      TSCallSignatureDeclaration: checkReturnType,
+      TSConstructSignatureDeclaration: checkReturnType,
+      TSConstructorType: checkReturnType,
+      TSDeclareFunction: checkReturnType,
+      TSEmptyBodyFunctionExpression: checkReturnType,
+      TSFunctionType: checkReturnType,
+      TSMethodSignature: checkReturnType,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,79 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+  if (type.type === 'TSParenthesizedType')
+    return referencedAliasName(type.typeAnnotation);
+  if (type.type !== 'TSTypeReference' || type.typeName.type !== 'Identifier')
+    return null;
+  return type.typeArguments === null ||
+    type.typeArguments === undefined ||
+    type.typeArguments.params.length === 0
+    ? type.typeName.name
+    : null;
+}
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.',
+    },
+    messages: {
+      unknownAlias:
+        'Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.',
+    },
+  },
+  createOnce(context) {
+    const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+    const resolvesToUnknown = (
+      type: ESTree.TSType,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === 'TSUnknownKeyword') return true;
+      if (type.type === 'TSParenthesizedType')
+        return resolvesToUnknown(type.typeAnnotation, visited);
+      const name = referencedAliasName(type);
+      if (name === null || visited.has(name)) return false;
+      const alias = aliases.get(name);
+      if (
+        alias === undefined ||
+        (alias.typeParameters !== null && alias.typeParameters !== undefined)
+      ) {
+        return false;
+      }
+      const nextVisited = new Set(visited);
+      nextVisited.add(name);
+      return resolvesToUnknown(alias.typeAnnotation, nextVisited);
+    };
+
+    return {
+      Program(node) {
+        aliases.clear();
+        for (const statement of node.body) {
+          const declaration =
+            statement.type === 'ExportNamedDeclaration'
+              ? statement.declaration
+              : statement;
+          if (declaration?.type === 'TSTypeAliasDeclaration') {
+            aliases.set(declaration.id.name, declaration);
+          }
+        }
+        for (const alias of aliases.values()) {
+          if (
+            !resolvesToUnknown(alias.typeAnnotation, new Set([alias.id.name]))
+          )
+            continue;
+          context.report({
+            node: alias.id,
+            messageId: 'unknownAlias',
+            data: { alias: alias.id.name },
+          });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,147 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+import {
+  classifyUnsafeDictionary,
+  classifyUnsafeDictionaryValue,
+  createTypeEnvironment,
+  type TypeEnvironment,
+} from '../shared/dictionary-types.ts';
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+  'JSDocNonNullableType',
+  'JSDocNullableType',
+  'JSDocUnknownType',
+  'TSAnyKeyword',
+  'TSArrayType',
+  'TSBigIntKeyword',
+  'TSBooleanKeyword',
+  'TSConditionalType',
+  'TSConstructorType',
+  'TSFunctionType',
+  'TSImportType',
+  'TSIndexedAccessType',
+  'TSInferType',
+  'TSIntersectionType',
+  'TSIntrinsicKeyword',
+  'TSLiteralType',
+  'TSMappedType',
+  'TSNamedTupleMember',
+  'TSNeverKeyword',
+  'TSNullKeyword',
+  'TSNumberKeyword',
+  'TSObjectKeyword',
+  'TSParenthesizedType',
+  'TSStringKeyword',
+  'TSSymbolKeyword',
+  'TSTemplateLiteralType',
+  'TSThisType',
+  'TSTupleType',
+  'TSTypeLiteral',
+  'TSTypeOperator',
+  'TSTypePredicate',
+  'TSTypeQuery',
+  'TSTypeReference',
+  'TSUndefinedKeyword',
+  'TSUnionType',
+  'TSUnknownKeyword',
+  'TSVoidKeyword',
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+  return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === 'Identifier' ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (current.type === 'TSTypeAliasDeclaration') return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function isPlainAliasConsumerUse(
+  node: ESTree.TSType,
+  environment: TypeEnvironment,
+): boolean {
+  if (node.type !== 'TSTypeReference' || node.typeArguments?.params.length)
+    return false;
+  const name = typeReferenceName(node);
+  return (
+    name !== null &&
+    environment.aliases.has(name) &&
+    !isInsideTypeAliasDeclaration(node)
+  );
+}
+
+function shouldReportType(
+  node: ESTree.TSType,
+  environment: TypeEnvironment,
+): boolean {
+  if (isPlainAliasConsumerUse(node, environment)) return false;
+  if (classifyUnsafeDictionary(node, environment) === null) return false;
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (
+      isTypeNode(current) &&
+      classifyUnsafeDictionary(current, environment) !== null
+    )
+      return false;
+    current = current.parent;
+  }
+  return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.',
+    },
+    messages: {
+      unsafeDictionary:
+        "This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+    },
+  },
+  createOnce(context) {
+    let environment: TypeEnvironment | null = null;
+    const report = (node: ESTree.Node, value: string) => {
+      context.report({ node, messageId: 'unsafeDictionary', data: { value } });
+    };
+    const reportIfUnsafe = (node: ESTree.TSType) => {
+      if (environment === null || !shouldReportType(node, environment)) return;
+      const unsafe = classifyUnsafeDictionary(node, environment);
+      if (unsafe === null) return;
+      report(node, unsafe.unsafeValue);
+    };
+
+    return {
+      Program(node) {
+        environment = createTypeEnvironment(node);
+      },
+      TSTypeReference: reportIfUnsafe,
+      TSTypeLiteral: reportIfUnsafe,
+      TSMappedType: reportIfUnsafe,
+      TSIndexSignature(node) {
+        if (
+          environment === null ||
+          node.typeAnnotation === null ||
+          node.parent.type === 'TSTypeLiteral'
+        )
+          return;
+        const unsafe = classifyUnsafeDictionaryValue(
+          node.typeAnnotation.typeAnnotation,
+          environment,
+        );
+        if (unsafe !== null) report(node, unsafe.unsafeValue);
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,419 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree, Variable } from '@oxlint/plugins';
+
+type BroadTypeKind = 'top' | 'object' | 'record';
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'TSDeclareFunction',
+  'TSEmptyBodyFunctionExpression',
+]);
+
+function unwrapExpressionParentheses(
+  expression: ESTree.Expression,
+): ESTree.Expression {
+  let current = expression;
+  while (current.type === 'ParenthesizedExpression')
+    current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === 'TSParenthesizedType')
+    current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === 'Identifier' ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return (
+    unwrapped.type === 'TSUnknownKeyword' || unwrapped.type === 'TSAnyKeyword'
+  );
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === 'TSStringKeyword' ||
+    unwrapped.type === 'TSNumberKeyword' ||
+    unwrapped.type === 'TSSymbolKeyword'
+  ) {
+    return true;
+  }
+  if (unwrapped.type === 'TSUnionType')
+    return unwrapped.types.every(isBroadRecordKeyType);
+  return (
+    unwrapped.type === 'TSTypeReference' &&
+    typeReferenceName(unwrapped) === 'PropertyKey'
+  );
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === 'TSTypeReference') {
+    if (typeReferenceName(unwrapped) === 'Readonly') {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== 'Record') return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== 'TSTypeLiteral' || unwrapped.members.length !== 1)
+    return false;
+  const [member] = unwrapped.members;
+  const [parameter] =
+    member?.type === 'TSIndexSignature' ? member.parameters : [];
+  return (
+    member?.type === 'TSIndexSignature' &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === 'TSUnknownKeyword' ||
+    unwrapped.type === 'TSAnyKeyword'
+  )
+    return 'top';
+  if (unwrapped.type === 'TSObjectKeyword') return 'object';
+  return isBroadRecordType(unwrapped) ? 'record' : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === 'TSAsExpression' ||
+    unwrapped.type === 'TSTypeAssertion'
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, '');
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case 'TSArrayType':
+    case 'TSConstructorType':
+    case 'TSFunctionType':
+    case 'TSMappedType':
+    case 'TSObjectKeyword':
+    case 'TSTupleType':
+      return true;
+    case 'TSTypeLiteral':
+      return unwrapped.members.length > 0;
+    case 'TSIntersectionType':
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case 'TSTypeOperator':
+      return (
+        unwrapped.operator === 'readonly' &&
+        isDefinitelyObjectType(unwrapped.typeAnnotation)
+      );
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.some(
+      (member) => member.type !== 'TSIndexSignature',
+    );
+  }
+
+  if (unwrapped.type !== 'TSTypeReference') return false;
+  if (typeReferenceName(unwrapped) === 'Readonly') {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== 'Record') return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 &&
+    parameters[1] !== undefined &&
+    !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(
+  variable: Variable,
+): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (
+      definition.type === 'Variable' &&
+      definition.node.type === 'VariableDeclarator'
+    ) {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (
+    unwrapped.type === 'TSAsExpression' ||
+    unwrapped.type === 'TSTypeAssertion'
+  ) {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === 'Literal' || unwrapped.type === 'TemplateLiteral') {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === 'ArrayExpression' ||
+    unwrapped.type === 'ArrowFunctionExpression' ||
+    unwrapped.type === 'ClassExpression' ||
+    unwrapped.type === 'FunctionExpression' ||
+    unwrapped.type === 'NewExpression' ||
+    unwrapped.type === 'ObjectExpression'
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== 'Identifier') return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) =>
+      identifier.typeAnnotation !== null &&
+      identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (
+      functionBoundary(annotatedIdentifier) !== boundary ||
+      broadTypeKind(annotation) !== null
+    ) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== 'VariableDeclaration' ||
+    declarator.parent.kind !== 'const' ||
+    declarator.init === null ||
+    variable.references.some(
+      (reference) => reference.isWrite() && !reference.init,
+    ) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== 'VariableDeclaration' ||
+    declarator.parent.kind !== 'const' ||
+    declarator.id.type !== 'Identifier' ||
+    declarator.init === null ||
+    variable.references.some(
+      (reference) => reference.isWrite() && !reference.init,
+    )
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null
+      ? null
+      : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind =
+    declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(
+    originalExpression,
+    scopes,
+    boundary,
+    new Set([variable]),
+  );
+  return evidence === null
+    ? null
+    : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === 'top') return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === 'object') return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.',
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  createOnce(context) {
+    let scopes: Parameters<typeof resolvedVariableForIdentifier>[0] = [];
+
+    const checkAssertion = (
+      node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+    ) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== 'Identifier') return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'widenThenAssert',
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      Program() {
+        scopes = context.sourceCode.scopeManager.scopes;
+      },
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -1,0 +1,72 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree, SourceCode } from '@oxlint/plugins';
+
+type TypeAssertion = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+const commentOwnerKinds = new Set([
+  'ExpressionStatement',
+  'PropertyDefinition',
+  'ReturnStatement',
+  'ThrowStatement',
+  'VariableDeclaration',
+]);
+
+function isConstAssertion(node: TypeAssertion): boolean {
+  return (
+    node.typeAnnotation.type === 'TSTypeReference' &&
+    node.typeAnnotation.typeName.type === 'Identifier' &&
+    node.typeAnnotation.typeName.name === 'const'
+  );
+}
+
+function hasSafetyComment(
+  sourceCode: SourceCode,
+  node: TypeAssertion,
+): boolean {
+  let current: ESTree.Node = node;
+  while (true) {
+    if (
+      sourceCode
+        .getCommentsBefore(current)
+        .some(
+          (comment) =>
+            comment.end <= node.start && /\bSAFETY\s*:/u.test(comment.value),
+        )
+    ) {
+      return true;
+    }
+    if (
+      commentOwnerKinds.has(current.type) ||
+      current.parent.type === 'Program'
+    )
+      return false;
+    current = current.parent;
+  }
+}
+
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.',
+    },
+    messages: {
+      missingSafetyComment:
+        'This type assertion has no `SAFETY:` justification. State the checked invariant immediately before the assertion or its containing statement.',
+    },
+  },
+  createOnce(context) {
+    const checkAssertion = (node: TypeAssertion) => {
+      if (isConstAssertion(node) || hasSafetyComment(context.sourceCode, node))
+        return;
+      context.report({ node, messageId: 'missingSafetyComment' });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,606 @@
+import type { ESTree } from '@oxlint/plugins';
+
+const BUILT_INS = new Set([
+  'Record',
+  'Readonly',
+  'Partial',
+  'Required',
+  'Pick',
+  'Omit',
+  'PropertyKey',
+  'NonNullable',
+]);
+const TRANSPARENT_WRAPPERS = new Set([
+  'Readonly',
+  'Partial',
+  'Required',
+  'NonNullable',
+]);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+  readonly type: ESTree.TSType;
+  readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+  readonly kind: 'unsafe-dictionary';
+  readonly unsafeValue: 'any' | 'empty-object' | 'object' | 'union' | 'unknown';
+};
+
+export type WideningTargetKind =
+  | 'anonymous object'
+  | 'generic container'
+  | 'object'
+  | 'open dictionary'
+  | 'unknown';
+
+export type WideningTarget = {
+  readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+  readonly aliases: ReadonlyMap<string, ESTree.TSTypeAliasDeclaration>;
+  readonly interfaces: ReadonlyMap<
+    string,
+    readonly ESTree.TSInterfaceDeclaration[]
+  >;
+  readonly shadowedBuiltIns: ReadonlySet<string>;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+  return statement.type === 'ExportNamedDeclaration' ||
+    statement.type === 'ExportDefaultDeclaration'
+    ? (statement.declaration ?? null)
+    : statement;
+}
+
+export function createTypeEnvironment(
+  program: ESTree.Program,
+): TypeEnvironment {
+  const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+  const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+  const shadowedBuiltIns = new Set<string>();
+
+  for (const statement of program.body) {
+    const declaration = declaredStatement(statement);
+    if (declaration?.type === 'ImportDeclaration') {
+      for (const specifier of declaration.specifiers) {
+        if (BUILT_INS.has(specifier.local.name))
+          shadowedBuiltIns.add(specifier.local.name);
+      }
+      continue;
+    }
+
+    if (declaration?.type === 'TSTypeAliasDeclaration') {
+      const existing = aliases.get(declaration.id.name);
+      if (existing === undefined) aliases.set(declaration.id.name, declaration);
+      else shadowedBuiltIns.add(declaration.id.name);
+      if (BUILT_INS.has(declaration.id.name))
+        shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (declaration?.type === 'TSInterfaceDeclaration') {
+      const declarations = interfaces.get(declaration.id.name) ?? [];
+      declarations.push(declaration);
+      interfaces.set(declaration.id.name, declarations);
+      if (BUILT_INS.has(declaration.id.name))
+        shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (declaration?.type === 'TSEnumDeclaration') {
+      if (BUILT_INS.has(declaration.id.name))
+        shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (
+      (declaration?.type === 'ClassDeclaration' ||
+        declaration?.type === 'FunctionDeclaration') &&
+      declaration.id !== null
+    ) {
+      if (BUILT_INS.has(declaration.id.name))
+        shadowedBuiltIns.add(declaration.id.name);
+    }
+  }
+
+  return { aliases, interfaces, shadowedBuiltIns };
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === 'Identifier' ? type.typeName.name : null;
+}
+
+function isBuiltIn(name: string, environment: TypeEnvironment): boolean {
+  return BUILT_INS.has(name) && !environment.shadowedBuiltIns.has(name);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+  const unwrapped = unwrapTransparentType(type);
+  return (
+    unwrapped.type === 'TSTypeReference' &&
+    typeReferenceName(unwrapped) === name &&
+    (unwrapped.typeArguments === null ||
+      unwrapped.typeArguments === undefined ||
+      unwrapped.typeArguments.params.length === 0)
+  );
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (
+    current.type === 'TSParenthesizedType' ||
+    (current.type === 'TSTypeOperator' && current.operator === 'readonly')
+  ) {
+    current = current.typeAnnotation;
+  }
+  return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+  return unwrapTransparentType(type).type === 'TSNeverKeyword';
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+  return (
+    member.type === 'TSPropertySignature' &&
+    member.optional === true &&
+    member.typeAnnotation !== null &&
+    member.typeAnnotation !== undefined &&
+    isNeverType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+  return (
+    type.members.length === 0 || type.members.every(isEffectivelyEmptyMember)
+  );
+}
+
+function isEffectivelyEmptyInterface(
+  declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+  if (declarations.length !== 1) return false;
+  const [type] = declarations;
+  return (
+    type !== undefined &&
+    type.extends.length === 0 &&
+    (type.body.body.length === 0 ||
+      type.body.body.every(isEffectivelyEmptyMember))
+  );
+}
+
+function resolvedSubstitutionArgument(
+  type: ESTree.TSType,
+  base: TypeAliasEnvironment,
+  resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type !== 'TSTypeReference') return type;
+  const name = typeReferenceName(unwrapped);
+  if (name === null || resolving.has(name)) return type;
+  const substitution = base.get(name);
+  if (substitution === undefined) return type;
+  const nextResolving = new Set(resolving);
+  nextResolving.add(name);
+  return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+  alias: ESTree.TSTypeAliasDeclaration,
+  type: ESTree.TSTypeReference,
+  base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+  const parameters = alias.typeParameters?.params ?? [];
+  const arguments_ = type.typeArguments?.params ?? [];
+  const next = new Map(base);
+  for (const [index, parameter] of parameters.entries()) {
+    const argument = arguments_[index] ?? parameter.default;
+    if (argument === null || argument === undefined) return null;
+    next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+  }
+  return next;
+}
+
+function unsafeDirectValue(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary['unsafeValue'] | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === 'TSUnknownKeyword') return 'unknown';
+  if (unwrapped.type === 'TSAnyKeyword') return 'any';
+  if (unwrapped.type === 'TSObjectKeyword') return 'object';
+  if (
+    unwrapped.type === 'TSTypeLiteral' &&
+    isEffectivelyEmptyTypeLiteral(unwrapped)
+  )
+    return 'empty-object';
+  if (unwrapped.type === 'TSUnionType') {
+    return unwrapped.types.some(
+      (member) =>
+        unsafeDirectValue(
+          member,
+          environment,
+          substitutions,
+          resolvingAliases,
+        ) !== null,
+    )
+      ? 'union'
+      : null;
+  }
+  if (unwrapped.type === 'TSIntersectionType') {
+    const unsafeMembers = unwrapped.types.map((member) =>
+      unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+    );
+    if (unsafeMembers.includes('any')) return 'any';
+    return unsafeMembers.length > 0 &&
+      unsafeMembers.every((member) => member !== null)
+      ? unsafeMembers[0]
+      : null;
+  }
+  if (unwrapped.type !== 'TSTypeReference') return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? null
+      : unsafeDirectValue(
+          wrapped,
+          environment,
+          substitutions,
+          resolvingAliases,
+        );
+  }
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? null
+      : unsafeDirectValue(
+          substitution,
+          environment,
+          substitutions,
+          resolvingAliases,
+        );
+  }
+  const interfaceDeclarations = environment.interfaces.get(name);
+  if (interfaceDeclarations !== undefined) {
+    return isEffectivelyEmptyInterface(interfaceDeclarations)
+      ? 'empty-object'
+      : null;
+  }
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return null;
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return null;
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return unsafeDirectValue(
+    alias.typeAnnotation,
+    environment,
+    nextSubstitutions,
+    nextResolving,
+  );
+}
+
+function dictionaryValueTypes(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+  const unwrapped = unwrapTransparentType(type);
+
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+      member.type === 'TSIndexSignature' && member.typeAnnotation !== null
+        ? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+        : [],
+    );
+  }
+
+  if (unwrapped.type === 'TSMappedType') {
+    return unwrapped.typeAnnotation === null
+      ? []
+      : [{ type: unwrapped.typeAnnotation, substitutions }];
+  }
+
+  if (unwrapped.type !== 'TSTypeReference') return [];
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return [];
+
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? []
+      : dictionaryValueTypes(
+          substitution,
+          environment,
+          substitutions,
+          resolvingAliases,
+        );
+  }
+
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? []
+      : dictionaryValueTypes(
+          wrapped,
+          environment,
+          substitutions,
+          resolvingAliases,
+        );
+  }
+
+  if (name === 'Record' && isBuiltIn(name, environment)) {
+    const value = unwrapped.typeArguments?.params[1] ?? null;
+    return value === null ? [] : [{ type: value, substitutions }];
+  }
+
+  if ((name === 'Pick' || name === 'Omit') && isBuiltIn(name, environment)) {
+    const source = unwrapped.typeArguments?.params[0];
+    return source === undefined
+      ? []
+      : dictionaryValueTypes(
+          source,
+          environment,
+          substitutions,
+          resolvingAliases,
+        );
+  }
+
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return [];
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return [];
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return dictionaryValueTypes(
+    alias.typeAnnotation,
+    environment,
+    nextSubstitutions,
+    nextResolving,
+  );
+}
+
+export function classifyUnsafeDictionaryValue(
+  valueType: ESTree.TSType,
+  environment: TypeEnvironment,
+): UnsafeDictionary | null {
+  const unsafeValue = unsafeDirectValue(
+    valueType,
+    environment,
+    new Map(),
+    new Set(),
+  );
+  return unsafeValue === null
+    ? null
+    : { kind: 'unsafe-dictionary', unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+): UnsafeDictionary | null {
+  for (const valueType of dictionaryValueTypes(
+    type,
+    environment,
+    new Map(),
+    new Set(),
+  )) {
+    const unsafeValue = unsafeDirectValue(
+      valueType.type,
+      environment,
+      valueType.substitutions,
+      new Set(),
+    );
+    if (unsafeValue !== null) return { kind: 'unsafe-dictionary', unsafeValue };
+  }
+  return null;
+}
+
+function resolvesToDictionary(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): boolean {
+  return (
+    dictionaryValueTypes(type, environment, substitutions, resolvingAliases)
+      .length > 0
+  );
+}
+
+export function classifyWideningTarget(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+): WideningTarget | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === 'TSUnknownKeyword') return { kind: 'unknown' };
+  if (unwrapped.type === 'TSObjectKeyword') return { kind: 'object' };
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.some(
+      (member) => member.type === 'TSIndexSignature',
+    )
+      ? { kind: 'open dictionary' }
+      : unwrapped.members.length > 0
+        ? { kind: 'anonymous object' }
+        : null;
+  }
+  if (unwrapped.type === 'TSMappedType') return { kind: 'open dictionary' };
+  if (unwrapped.type !== 'TSTypeReference') return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? null
+      : classifyWideningTarget(wrapped, environment);
+  }
+  if (name === 'Record' && isBuiltIn(name, environment))
+    return { kind: 'open dictionary' };
+  const alias = environment.aliases.get(name);
+  if (alias === undefined) return null;
+  if ((alias.typeParameters?.params.length ?? 0) > 0) {
+    const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+    return substitutions !== null &&
+      resolvesToDictionary(
+        alias.typeAnnotation,
+        environment,
+        substitutions,
+        new Set([name]),
+      )
+      ? { kind: 'generic container' }
+      : null;
+  }
+  const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+  if (substitutions === null) return null;
+  const resolved = classifyAliasBroadTarget(
+    alias.typeAnnotation,
+    environment,
+    substitutions,
+    new Set([name]),
+  );
+  return resolved;
+}
+
+function isBroadMappedKey(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+): boolean {
+  const unwrapped = unwrapTransparentType(type);
+  if (
+    unwrapped.type === 'TSStringKeyword' ||
+    unwrapped.type === 'TSNumberKeyword' ||
+    unwrapped.type === 'TSSymbolKeyword'
+  ) {
+    return true;
+  }
+  if (unwrapped.type === 'TSUnionType') {
+    return unwrapped.types.every((member) =>
+      isBroadMappedKey(member, environment, substitutions),
+    );
+  }
+  if (unwrapped.type !== 'TSTypeReference') return false;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return false;
+  const substitution = substitutions.get(name);
+  if (
+    substitution !== undefined &&
+    !isUnappliedReferenceTo(substitution, name)
+  ) {
+    return isBroadMappedKey(substitution, environment, substitutions);
+  }
+  return name === 'PropertyKey' && isBuiltIn(name, environment);
+}
+
+function classifyAliasBroadTarget(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === 'TSUnknownKeyword') return { kind: 'unknown' };
+  if (unwrapped.type === 'TSObjectKeyword') return { kind: 'object' };
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.some(
+      (member) => member.type === 'TSIndexSignature',
+    )
+      ? { kind: 'open dictionary' }
+      : null;
+  }
+  if (unwrapped.type === 'TSMappedType') {
+    return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+      ? { kind: 'open dictionary' }
+      : null;
+  }
+  if (unwrapped.type !== 'TSTypeReference') return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? null
+      : classifyAliasBroadTarget(
+          substitution,
+          environment,
+          substitutions,
+          resolvingAliases,
+        );
+  }
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? null
+      : classifyAliasBroadTarget(
+          wrapped,
+          environment,
+          substitutions,
+          resolvingAliases,
+        );
+  }
+  if (name === 'Record' && isBuiltIn(name, environment)) {
+    return { kind: 'open dictionary' };
+  }
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return null;
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return null;
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return classifyAliasBroadTarget(
+    alias.typeAnnotation,
+    environment,
+    nextSubstitutions,
+    nextResolving,
+  );
+}
+
+export function isPopulatedObjectExpression(
+  expression: ESTree.Expression,
+): boolean {
+  let current = expression;
+  while (
+    current.type === 'ParenthesizedExpression' ||
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSTypeAssertion' ||
+    current.type === 'TSNonNullExpression'
+  ) {
+    current = current.expression;
+  }
+  return current.type === 'ObjectExpression' && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(
+  expression: ESTree.Expression,
+): boolean {
+  let current = expression;
+  while (
+    current.type === 'ParenthesizedExpression' ||
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSTypeAssertion' ||
+    current.type === 'TSNonNullExpression' ||
+    current.type === 'TSSatisfiesExpression'
+  ) {
+    current = current.expression;
+  }
+  if (current.type === 'ObjectExpression') return true;
+  return (
+    current.type === 'ArrayExpression' ||
+    current.type === 'ArrowFunctionExpression' ||
+    current.type === 'ClassExpression' ||
+    current.type === 'FunctionExpression' ||
+    current.type === 'NewExpression' ||
+    current.type === 'Literal' ||
+    current.type === 'TemplateLiteral' ||
+    current.type === 'UnaryExpression'
+  );
+}

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -1,0 +1,65 @@
+import type { ESTree } from '@oxlint/plugins';
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+
+function isNode(value: unknown): value is ESTree.Node {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    typeof value.type === 'string'
+  );
+}
+
+function collectInferTypeParameterNames(
+  node: ESTree.Node,
+  visitorKeys: VisitorKeys,
+  names: Set<string>,
+): void {
+  if (node.type === 'TSInferType') names.add(node.typeParameter.name.name);
+  const record = node as unknown as Readonly<Record<string, unknown>>;
+  for (const key of visitorKeys[node.type] ?? []) {
+    const value = record[key];
+    if (isNode(value)) {
+      collectInferTypeParameterNames(value, visitorKeys, names);
+      continue;
+    }
+    if (!Array.isArray(value)) continue;
+    for (const child of value) {
+      if (isNode(child))
+        collectInferTypeParameterNames(child, visitorKeys, names);
+    }
+  }
+}
+
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export function lexicalTypeParameterNames(
+  node: ESTree.Node,
+  visitorKeys: VisitorKeys,
+): ReadonlySet<string> {
+  const names = new Set<string>();
+  let descendant: ESTree.Node = node;
+  let current: ESTree.Node | null = node;
+  while (current !== null && current.type !== 'Program') {
+    if ('typeParameters' in current) {
+      for (const parameter of current.typeParameters?.params ?? []) {
+        names.add(parameter.name.name);
+      }
+    }
+    if (
+      current.type === 'TSMappedType' &&
+      (descendant === current.nameType || descendant === current.typeAnnotation)
+    ) {
+      names.add(current.key.name);
+    }
+    if (
+      current.type === 'TSConditionalType' &&
+      descendant === current.trueType
+    ) {
+      collectInferTypeParameterNames(current.extendsType, visitorKeys, names);
+    }
+    descendant = current;
+    current = current.parent;
+  }
+  return names;
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,44 @@
+import type { ESTree, Scope, SourceCode, Variable } from '@oxlint/plugins';
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function isGlobalReflect(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): boolean {
+  if (expression.type !== 'Identifier' || expression.name !== 'Reflect')
+    return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (
+    !('property' in callee) ||
+    !('object' in callee) ||
+    !('computed' in callee)
+  )
+    return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === 'Literal' && property.value === methodName
+    : property.type === 'Identifier' && property.name === methodName;
+}


### PR DESCRIPTION
## What

Vendors [dmmulroy/anti-slop](https://github.com/dmmulroy/anti-slop) as an oxlint JS plugin at `tools/oxlint/anti-slop/`, with all 15 generic rules enabled at `error`.

- `.oxlintrc.json`: adds `jsPlugins`, the 15 rules, and ignore patterns for `.agent/**`, `.agents/**`, `.claude/**`, `tools/oxlint/anti-slop/**`.
- `package.json`: `oxlint` 1.71.0 -> 1.79.0, adds `@oxlint/plugins` 1.79.0.
- The upstream `effect/` rule group is deleted; this repo has no Effect dependency.

## Why the oxlint bump

The JS plugin API needs `oxlint` and `@oxlint/plugins` at the same version, and `@oxlint/plugins` publishes nothing below 1.73.0. 1.71.0 could not load the plugin at all.

## Reviewer notes

**CI lint will fail on this branch.** The new rules report 21 errors in existing source. They are not fixed here, because installing rules and migrating code are separate changes:

| Rule | Count | Files |
| --- | --- | --- |
| `no-runtime-typeof` | 10 | `src/core.ts`, `src/parsePdf.ts`, `src/resolveInput.ts`, 2 tests |
| `require-safety-comment-for-type-assertion` | 8 | `src/core.ts`, `src/getPdfMetadata.ts` |
| `no-unknown-parameters` | 2 | `src/getPdfMetadata.ts` |
| `no-unsafe-dictionary-type` | 1 | `src/getPdfMetadata.ts` |

The 8 `SAFETY:` comments are mechanical. `no-runtime-typeof` is not: `resolveInput` branches on `string | Buffer | Stream` by design, so it needs either a discriminated input type or a per-file exception. Decide before merge.

`pnpm typecheck` passes. The vendored plugin is outside `tsconfig.json` include.

Upstream expects the vendored copy to be edited locally, not tracked as a fixed dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)